### PR TITLE
ChiliProject 2.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+gem "inifile",  "~>0.4.1"
+gem "lockfile",  "~>1.4.3"
+gem "net-ssh",  "~>2.1.4"

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
+source :rubygems
 gem "inifile",  "~>0.4.1"
 gem "lockfile",  "~>1.4.3"
 gem "net-ssh",  "~>2.1.4"


### PR DESCRIPTION
Hi,
While installing your plugin into chiliproject 2.0.0 I had an error getting the required gems even if they where installed during the plugin migration.
This is because cp started to use bundler from 2.0.0 up, so you need a Gemfile into your root path to express your dependencies. 
I created one using the versions I had installed (should be the most recent).
Regards,
Mat
