### PR TITLE
fix 'invalid multibyte char (US-ASCII)' as per Ruby 1.9 Bug #1238

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require 'redmine'
 require_dependency 'principal'
 require_dependency 'user'


### PR DESCRIPTION
init.rb throws an _invalid multibyte char (US-ASCII)_ on line 15, the _author_ variable, when launching with:
- Ruby 1.9.2.136
- Phusion Passenger 3.0.8
- ChiliProject 2.1.1
- Redmine Git Hosting Plugin v0.3.0

See http://RedMine.Ruby-Lang.org/issues/1238

Adding:
    # coding: utf-8
as the first line of init.rb fixes it.
