### PR TITLE
GitHub recommends the `-u` option in `git push -u origin master`. I figur

### DIFF
--- a/app/views/repositories/git_instructions.html.erb
+++ b/app/views/repositories/git_instructions.html.erb
@@ -17,11 +17,11 @@
 	git add readme.txt
 	git commit -m 'Initializing <%= @project %> repository'
 	git remote add origin <%= git_ssh_url %>
-	git push origin master
+	git push -u origin master
 </pre>
 <h2>Existing Git Repo?</h2>
 <pre>	cd existing_git_repo
 	git remote add origin <%= git_ssh_url %>
-	git push origin master
+	git push -u origin master
 </pre>    
 </div>


### PR DESCRIPTION
GitHub recommends the `-u` option in `git push -u origin master`. I figured I'd update this to match.
