### PR TITLE
Extended features

### DIFF
--- a/app/models/gitolite_public_key.rb
+++ b/app/models/gitolite_public_key.rb
@@ -28,7 +28,7 @@ class GitolitePublicKey < ActiveRecord::Base
 		#
 		# also, it ensures that it is very, very unlikely to conflict with any
 		# existing key name if gitolite config is also being edited manually
-		self.identifier ||= "#{Setting.plugin_redmine_git_hosting['gitIdPrefix'}#{self.user.login.underscore}#{Setting.plugin_redmine_git_hosting['gitIdSuffix']}"
+		self.identifier ||= "#{Setting.plugin_redmine_git_hosting['gitIdPrefix']}#{self.user.login.underscore}#{Setting.plugin_redmine_git_hosting['gitIdSuffix']}"
 	end
 
 	def to_s ; title ; end

--- a/app/models/gitolite_public_key.rb
+++ b/app/models/gitolite_public_key.rb
@@ -28,7 +28,7 @@ class GitolitePublicKey < ActiveRecord::Base
 		#
 		# also, it ensures that it is very, very unlikely to conflict with any
 		# existing key name if gitolite config is also being edited manually
-		self.identifier ||= "redmine_#{self.user.login.underscore}_#{Time.now.to_i.to_s}_#{Time.now.usec.to_s}".gsub(/[^0-9a-zA-Z\-]/,'_')
+		self.identifier ||= "#{Setting.plugin_redmine_git_hosting['gitIdPrefix'}#{self.user.login.underscore}#{Setting.plugin_redmine_git_hosting['gitIdSuffix']}"
 	end
 
 	def to_s ; title ; end

--- a/app/views/settings/_redmine_git_hosting.html.erb
+++ b/app/views/settings/_redmine_git_hosting.html.erb
@@ -37,6 +37,12 @@
                <br />
     </p>
 
+    <p>
+      <label><%= l(:label_git_admin_user)%></label>
+      <%= text_field_tag("settings[gitAdminUser]", @settings['gitAdminUser'].split(/[\r\n\t ,;]+/).join("\n"), :size => 60) %>
+               <br />
+    </p>
+
 	<p>
 		<label><%= l(:label_gitolite_identity_file)%></label>
 		<%= text_field_tag("settings[gitoliteIdentityFile]", @settings['gitoliteIdentityFile'], :size => 60) %>

--- a/app/views/settings/_redmine_git_hosting.html.erb
+++ b/app/views/settings/_redmine_git_hosting.html.erb
@@ -31,6 +31,12 @@
 		<br />
 	</p>
 
+    <p>
+      <label><%= l(:label_git_config_file)%></label>
+      <%= text_field_tag("settings[gitConfigFile]", @settings['gitConfigFile'].split(/[\r\n\t ,;]+/).join("\n"), :size => 60) %>
+               <br />
+    </p>
+
 	<p>
 		<label><%= l(:label_gitolite_identity_file)%></label>
 		<%= text_field_tag("settings[gitoliteIdentityFile]", @settings['gitoliteIdentityFile'], :size => 60) %>

--- a/app/views/settings/_redmine_git_hosting.html.erb
+++ b/app/views/settings/_redmine_git_hosting.html.erb
@@ -38,6 +38,16 @@
     </p>
 
     <p>
+      <label><%= l(:label_git_id_prefix)%></label>
+      <%= text_field_tag("settings[gitIdPrefix]", @settings['gitIdPrefix'].split(/[\r\n\t ,;]+/).join("\n"), :size => 60) %>
+               <br />
+    </p>
+    <p>
+      <label><%= l(:label_git_id_suffix)%></label>
+      <%= text_field_tag("settings[gitIdSuffix]", @settings['gitIdSuffix'].split(/[\r\n\t ,;]+/).join("\n"), :size => 60) %>
+               <br />
+    </p>
+    <p>
       <label><%= l(:label_git_admin_user)%></label>
       <%= text_field_tag("settings[gitAdminUser]", @settings['gitAdminUser'].split(/[\r\n\t ,;]+/).join("\n"), :size => 60) %>
                <br />

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,10 +4,10 @@
   label_git_server: Gitolite Server Domain
   label_http_server: HTTP Server Domain (for git http urls)
   label_git_user: Git Username
-  label_git_config_file: "gitolite.conf"
+  label_git_config_file: "Config file (to save managed repos)"
   label_git_admin_user: "Gitolite Admin User"
-  label_git_id_prefix: "Gitolite id prefix"
-  label_git_id_suffix: "Gitolite id suffix"
+  label_git_id_prefix: "Gitolite Id prefix"
+  label_git_id_suffix: "Gitolite Id suffix"
   label_gitolite_identity_public_key_file: Gitolite SSH Identity File (Public Key)
   label_gitolite_identity_file: Gitolite SSH Identity File (Private Key)
   label_git_repository_base_path: Git Repository Base Path (Relative to git user home)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,6 +4,7 @@
   label_git_server: Gitolite Server Domain
   label_http_server: HTTP Server Domain (for git http urls)
   label_git_user: Git Username
+  label_git_config_file: "gitolite.conf"
   label_gitolite_identity_public_key_file: Gitolite SSH Identity File (Public Key)
   label_gitolite_identity_file: Gitolite SSH Identity File (Private Key)
   label_git_repository_base_path: Git Repository Base Path (Relative to git user home)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,6 +5,7 @@
   label_http_server: HTTP Server Domain (for git http urls)
   label_git_user: Git Username
   label_git_config_file: "gitolite.conf"
+  label_git_admin_user: "Gitolite Admin User"
   label_gitolite_identity_public_key_file: Gitolite SSH Identity File (Public Key)
   label_gitolite_identity_file: Gitolite SSH Identity File (Private Key)
   label_git_repository_base_path: Git Repository Base Path (Relative to git user home)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,6 +6,8 @@
   label_git_user: Git Username
   label_git_config_file: "gitolite.conf"
   label_git_admin_user: "Gitolite Admin User"
+  label_git_id_prefix: "Gitolite id prefix"
+  label_git_id_suffix: "Gitolite id suffix"
   label_gitolite_identity_public_key_file: Gitolite SSH Identity File (Public Key)
   label_gitolite_identity_file: Gitolite SSH Identity File (Private Key)
   label_git_repository_base_path: Git Repository Base Path (Relative to git user home)

--- a/init.rb
+++ b/init.rb
@@ -16,6 +16,7 @@ Redmine::Plugin.register :redmine_git_hosting do
 		'httpServer' => 'localhost',
 		'gitServer' => 'localhost',
 		'gitUser' => 'git',
+        'gitConfigFile' => 'gitolite.conf',
 		'gitRepositoryBasePath' => 'repositories/',
 		'gitoliteIdentityFile' => RAILS_ROOT + '/.ssh/gitolite_admin_id_rsa',
 		'gitoliteIdentityPublicKeyFile' => RAILS_ROOT + '/.ssh/gitolite_admin_id_rsa.pub',

--- a/init.rb
+++ b/init.rb
@@ -17,6 +17,7 @@ Redmine::Plugin.register :redmine_git_hosting do
 		'gitServer' => 'localhost',
 		'gitUser' => 'git',
         'gitConfigFile' => 'gitolite.conf',
+        'gitAdminUser' => 'git-admin',
 		'gitRepositoryBasePath' => 'repositories/',
 		'gitoliteIdentityFile' => RAILS_ROOT + '/.ssh/gitolite_admin_id_rsa',
 		'gitoliteIdentityPublicKeyFile' => RAILS_ROOT + '/.ssh/gitolite_admin_id_rsa.pub',

--- a/init.rb
+++ b/init.rb
@@ -18,6 +18,8 @@ Redmine::Plugin.register :redmine_git_hosting do
 		'gitUser' => 'git',
         'gitConfigFile' => 'gitolite.conf',
         'gitAdminUser' => 'git-admin',
+        'gitIdPrefix' => 'redmine_',
+        'gitIdSuffix' => '',
 		'gitRepositoryBasePath' => 'repositories/',
 		'gitoliteIdentityFile' => RAILS_ROOT + '/.ssh/gitolite_admin_id_rsa',
 		'gitoliteIdentityPublicKeyFile' => RAILS_ROOT + '/.ssh/gitolite_admin_id_rsa.pub',

--- a/lib/git_hosting.rb
+++ b/lib/git_hosting.rb
@@ -320,7 +320,7 @@ module GitHosting
 		clone_or_pull_gitolite_admin
 
 		# rename in conf file
-		conf = GitoliteConfig.new(File.join(local_dir, 'gitolite-admin', 'conf', 'gitolite.conf'))
+		conf = GitoliteConfig.new(File.join(local_dir, 'gitolite-admin', 'conf', Setting.plugin_redmine_git_hosting['gitConfigFile']))
 		conf.rename_repo( old_name, new_name )
 		conf.save
 
@@ -332,7 +332,7 @@ module GitHosting
 
 		# commit / push changes to gitolite admin repo
 		%x[env GIT_SSH=#{gitolite_ssh()} git --git-dir='#{local_dir}/gitolite-admin/.git' --work-tree='#{local_dir}/gitolite-admin' add keydir/*]
-		%x[env GIT_SSH=#{gitolite_ssh()} git --git-dir='#{local_dir}/gitolite-admin/.git' --work-tree='#{local_dir}/gitolite-admin' add conf/gitolite.conf]
+		%x[env GIT_SSH=#{gitolite_ssh()} git --git-dir='#{local_dir}/gitolite-admin/.git' --work-tree='#{local_dir}/gitolite-admin' add conf/#{Setting.plugin_redmine_git_hosting['gitConfigFile']}]
 		%x[env GIT_SSH=#{gitolite_ssh()} git --git-dir='#{local_dir}/gitolite-admin/.git' --work-tree='#{local_dir}/gitolite-admin' config user.email '#{Setting.mail_from}']
 		%x[env GIT_SSH=#{gitolite_ssh()} git --git-dir='#{local_dir}/gitolite-admin/.git' --work-tree='#{local_dir}/gitolite-admin' config user.name 'Redmine']
 		%x[env GIT_SSH=#{gitolite_ssh()} git --git-dir='#{local_dir}/gitolite-admin/.git' --work-tree='#{local_dir}/gitolite-admin' commit -a -m 'updated by Redmine' ]
@@ -376,7 +376,7 @@ module GitHosting
 
 
 			local_dir = get_tmp_dir()
-			conf = GitoliteConfig.new(File.join(local_dir, 'gitolite-admin', 'conf', 'gitolite.conf'))
+			conf = GitoliteConfig.new(File.join(local_dir, 'gitolite-admin', 'conf', Setting.                                           plugin_redmine_git_hosting['gitConfigFile']))
 			orig_repos = conf.all_repos
 			new_repos = []
 			new_projects = []
@@ -454,7 +454,7 @@ module GitHosting
 
 			if changed
 				%x[env GIT_SSH=#{gitolite_ssh()} git --git-dir='#{local_dir}/gitolite-admin/.git' --work-tree='#{local_dir}/gitolite-admin' add keydir/*]
-				%x[env GIT_SSH=#{gitolite_ssh()} git --git-dir='#{local_dir}/gitolite-admin/.git' --work-tree='#{local_dir}/gitolite-admin' add conf/gitolite.conf]
+				%x[env GIT_SSH=#{gitolite_ssh()} git --git-dir='#{local_dir}/gitolite-admin/.git' --work-tree='#{local_dir}/gitolite-admin' add conf/#{Setting.plugin_redmine_git_hosting['gitConfigFile']}]
 				%x[env GIT_SSH=#{gitolite_ssh()} git --git-dir='#{local_dir}/gitolite-admin/.git' --work-tree='#{local_dir}/gitolite-admin' config user.email '#{Setting.mail_from}']
 				%x[env GIT_SSH=#{gitolite_ssh()} git --git-dir='#{local_dir}/gitolite-admin/.git' --work-tree='#{local_dir}/gitolite-admin' config user.name 'Redmine']
 				%x[env GIT_SSH=#{gitolite_ssh()} git --git-dir='#{local_dir}/gitolite-admin/.git' --work-tree='#{local_dir}/gitolite-admin' commit -a -m 'updated by Redmine' ]

--- a/lib/git_hosting.rb
+++ b/lib/git_hosting.rb
@@ -376,7 +376,7 @@ module GitHosting
 
 
 			local_dir = get_tmp_dir()
-			conf = GitoliteConfig.new(File.join(local_dir, 'gitolite-admin', 'conf', Setting.                                           plugin_redmine_git_hosting['gitConfigFile']))
+			conf = GitoliteConfig.new(File.join(local_dir, 'gitolite-admin', 'conf', Setting.plugin_redmine_git_hosting['gitConfigFile']))
 			orig_repos = conf.all_repos
 			new_repos = []
 			new_projects = []

--- a/lib/gitolite_conf.rb
+++ b/lib/gitolite_conf.rb
@@ -57,7 +57,7 @@ module GitHosting
 			@original_content = []
 			@repositories = ActiveSupport::OrderedHash.new
 			cur_repo_name = nil
-            File.new(@path, "w") unless File.exists(@path)
+            File.new(@path, "w") unless File.exists?(@path)
 			File.open(@path).each_line do |line|
 				@original_content << line
 				tokens = line.strip.split

--- a/lib/gitolite_conf.rb
+++ b/lib/gitolite_conf.rb
@@ -57,6 +57,7 @@ module GitHosting
 			@original_content = []
 			@repositories = ActiveSupport::OrderedHash.new
 			cur_repo_name = nil
+            File.new(@path, "w") unless File.exists(@path)
 			File.open(@path).each_line do |line|
 				@original_content << line
 				tokens = line.strip.split

--- a/lib/gitolite_conf.rb
+++ b/lib/gitolite_conf.rb
@@ -89,7 +89,7 @@ module GitHosting
 			# any permission anyway, this isn't really a security risk.
 			# If no users are defined, this ensures the repo actually
 			# gets created, hence it's necessary.
-			admin_user = @repositories["gitolite-admin"].rights["RW+".to_sym][0]
+			admin_user = Setting.plugin_redmine_git_hosting['gitAdminUser']
 			@repositories.each do |repo, rights|
 				content << "repo\t#{repo}"
 				has_users=false


### PR DESCRIPTION
I didn't do my development on a clone of my fork so everything is rolled together in a single branch.  The main changes are:
- Allow setting a config file to use rather than gitolite.conf
- Allow setting the gitolite admin user, this was needed in case you don't use gitolite.conf, you can't parse out the admin user.
- Allow the ability to set gitolite id prefix/suffixes

The only caveat is if you use a separate file for your managed repositories, you need to provide instructions that 'include "managed_file.conf"' be added to gitolite.conf one time so the repos all get pulled in.
