### PR TITLE
Performance fix for redmine_git_hosting.

### DIFF
--- a/app/controllers/gitolite_public_keys_controller.rb
+++ b/app/controllers/gitolite_public_keys_controller.rb
@@ -18,12 +18,14 @@ class GitolitePublicKeysController < ApplicationController
 	end
 
 	def update
+        	GitHostingObserver.set_update_active(false)
 		if @gitolite_public_key.update_attributes(params[:public_key])
 			flash[:notice] = l(:notice_public_key_updated)
 			redirect_to url_for(:controller => 'my', :action => 'account')
 		else
 			render :action => 'edit'
 		end
+        	GitHostingObserver.set_update_active(true)
 	end
 
 	def create

--- a/app/controllers/gitolite_public_keys_controller.rb
+++ b/app/controllers/gitolite_public_keys_controller.rb
@@ -10,9 +10,11 @@ class GitolitePublicKeysController < ApplicationController
 	end
 
 	def delete
+        	GitHostingObserver.set_update_active(false)
 		@gitolite_public_key[:active] = 0
 		@gitolite_public_key.save
 		redirect_to url_for(:controller => 'my', :action => 'account')
+        	GitHostingObserver.set_update_active(true)
 	end
 
 	def update
@@ -25,6 +27,7 @@ class GitolitePublicKeysController < ApplicationController
 	end
 
 	def create
+        	GitHostingObserver.set_update_active(false)
 		@gitolite_public_key = GitolitePublicKey.new(params[:public_key].merge(:user => @user))
 		if @gitolite_public_key.save
 			flash[:notice] = l(:notice_public_key_added)
@@ -32,6 +35,7 @@ class GitolitePublicKeysController < ApplicationController
 			@gitolite_public_key = GitolitePublicKey.new(:user => @user)
 		end
 		redirect_to url_for(:controller => 'my', :action => 'account')
+        	GitHostingObserver.set_update_active(true)
 	end
 
 	protected

--- a/db/migrate/20111119170948_add_indexes_to_gitolite_public_key.rb
+++ b/db/migrate/20111119170948_add_indexes_to_gitolite_public_key.rb
@@ -1,0 +1,11 @@
+class AddIndexesToGitolitePublicKey < ActiveRecord::Migration
+  def self.up
+    add_index :gitolite_public_keys, :user_id
+    add_index :gitolite_public_keys, :identifier
+  end
+
+  def self.down
+    remove_index :gitolite_public_keys, :user_id
+    remove_index :gitolite_public_keys, :identifier
+  end
+end

--- a/init.rb
+++ b/init.rb
@@ -74,6 +74,14 @@ Dispatcher.to_prepare :redmine_git_patches do
   require 'git_hosting/patches/members_controller_patch'
   MembersController.send(:include, GitHosting::Patches::MembersControllerPatch)
 
+  require_dependency 'users_controller'
+  require 'git_hosting/patches/users_controller_patch'
+  UsersController.send(:include, GitHosting::Patches::UsersControllerPatch)
+
+  require_dependency 'roles_controller'
+  require 'git_hosting/patches/roles_controller_patch'
+  RolesController.send(:include, GitHosting::Patches::RolesControllerPatch)
+
   require_dependency 'git_hosting/patches/repository_cia_filters'
 end
 

--- a/init.rb
+++ b/init.rb
@@ -66,6 +66,14 @@ Dispatcher.to_prepare :redmine_git_patches do
   require 'git_hosting/patches/git_repository_patch'
   Repository::Git.send(:include, GitHosting::Patches::GitRepositoryPatch)
 
+  require_dependency 'sys_controller'
+  require 'git_hosting/patches/sys_controller_patch'
+  SysController.send(:include, GitHosting::Patches::SysControllerPatch)
+
+  require_dependency 'members_controller'
+  require 'git_hosting/patches/members_controller_patch'
+  MembersController.send(:include, GitHosting::Patches::MembersControllerPatch)
+
   require_dependency 'git_hosting/patches/repository_cia_filters'
 end
 

--- a/lib/git_hosting/patches/git_repository_patch.rb
+++ b/lib/git_hosting/patches/git_repository_patch.rb
@@ -9,6 +9,16 @@ module GitHosting
 				true
 			end
 
+                        def fetch_changesets_with_disable_update
+                        	# Turn of updates during repository update
+                        	GitHostingObserver.set_update_active(false);
+
+                        	# Do actual update
+                        	fetch_changesets_without_disable_update
+
+                        	# Reenable updates to perform a single update
+				GitHostingObserver.set_update_active(true);
+                        end
 
 			def self.included(base)
 				base.class_eval do
@@ -17,6 +27,7 @@ module GitHosting
 				begin
 					base.send(:alias_method_chain, :report_last_commit, :always_true)
 					base.send(:alias_method_chain, :extra_report_last_commit, :always_true)
+                                	base.send(:alias_method_chain, :fetch_changesets, :disable_update)
 				rescue
 				end
 

--- a/lib/git_hosting/patches/members_controller_patch.rb
+++ b/lib/git_hosting/patches/members_controller_patch.rb
@@ -1,0 +1,48 @@
+module GitHosting
+	module Patches
+		module MembersControllerPatch
+                        def new_with_disable_update
+                             	# Turn of updates during repository update
+                       		GitHostingObserver.set_update_active(false);
+
+                       		# Do actual update
+                       		new_without_disable_update
+
+                       		# Reenable updates to perform a single update
+				GitHostingObserver.set_update_active(true);
+                       	end
+                        def edit_with_disable_update
+                             	# Turn of updates during repository update
+                       		GitHostingObserver.set_update_active(false);
+
+                       		# Do actual update
+                       		edit_without_disable_update
+
+                       		# Reenable updates to perform a single update
+				GitHostingObserver.set_update_active(true);
+                       	end
+                        def destroy_with_disable_update
+                             	# Turn of updates during repository update
+                       		GitHostingObserver.set_update_active(false);
+
+                       		# Do actual update
+                       		destroy_without_disable_update
+
+                       		# Reenable updates to perform a single update
+				GitHostingObserver.set_update_active(true);
+                       	end
+
+			def self.included(base)
+				base.class_eval do
+					unloadable
+				end
+                        	begin
+                                	base.send(:alias_method_chain, :new, :disable_update)
+                                	base.send(:alias_method_chain, :edit, :disable_update)
+                                	base.send(:alias_method_chain, :destroy, :disable_update)
+                                rescue
+                                end
+			end
+		end
+	end
+end

--- a/lib/git_hosting/patches/repository_patch.rb
+++ b/lib/git_hosting/patches/repository_patch.rb
@@ -25,8 +25,17 @@ module GitHosting
 					end
 					return new_repo
 				end
-			end
+                                def fetch_changesets_with_disable_update
+                                	# Turn of updates during repository update
+                        		GitHostingObserver.set_update_active(false);
 
+                        		# Do actual update
+                        		fetch_changesets_without_disable_update
+
+                        		# Reenable updates to perform a single update
+					GitHostingObserver.set_update_active(true);
+                        	end
+			end
 
 			def self.included(base)
 				base.extend(ClassMethods)
@@ -34,9 +43,9 @@ module GitHosting
 					unloadable
 					class << self
 						alias_method_chain :factory, :git_extra_init
+		                                alias_method_chain :fetch_changesets, :disable_update
 					end
 				end
-
 			end
 		end
 	end

--- a/lib/git_hosting/patches/roles_controller_patch.rb
+++ b/lib/git_hosting/patches/roles_controller_patch.rb
@@ -1,0 +1,36 @@
+module GitHosting
+	module Patches
+		module RolesControllerPatch
+                        def edit_with_disable_update
+                             	# Turn of updates during repository update
+                       		GitHostingObserver.set_update_active(false);
+
+                       		# Do actual update
+                       		edit_without_disable_update
+
+                       		# Reenable updates to perform a single update
+				GitHostingObserver.set_update_active(true);
+                       	end
+                        def destroy_with_disable_update
+                             	# Turn of updates during repository update
+                       		GitHostingObserver.set_update_active(false);
+
+                       		# Do actual update
+                       		destroy_without_disable_update
+
+                       		# Reenable updates to perform a single update
+				GitHostingObserver.set_update_active(true);
+                       	end
+			def self.included(base)
+				base.class_eval do
+					unloadable
+				end
+                        	begin
+                                	base.send(:alias_method_chain, :edit, :disable_update)
+                                	base.send(:alias_method_chain, :destroy, :disable_update)
+                                rescue
+                                end
+			end
+		end
+	end
+end

--- a/lib/git_hosting/patches/sys_controller_patch.rb
+++ b/lib/git_hosting/patches/sys_controller_patch.rb
@@ -1,0 +1,26 @@
+module GitHosting
+	module Patches
+		module SysControllerPatch
+                        def fetch_changesets_with_disable_update
+                             	# Turn of updates during repository update
+                       		GitHostingObserver.set_update_active(false);
+
+                       		# Do actual update
+                       		fetch_changesets_without_disable_update
+
+                       		# Reenable updates to perform a single update
+				GitHostingObserver.set_update_active(true);
+                       	end
+
+			def self.included(base)
+				base.class_eval do
+					unloadable
+				end
+                        	begin
+                                	base.send(:alias_method_chain, :fetch_changesets, :disable_update)
+                                rescue
+                                end
+			end
+		end
+	end
+end

--- a/lib/git_hosting/patches/users_controller_patch.rb
+++ b/lib/git_hosting/patches/users_controller_patch.rb
@@ -1,0 +1,59 @@
+module GitHosting
+	module Patches
+		module UsersControllerPatch
+                        def create_with_disable_update
+                             	# Turn of updates during repository update
+                       		GitHostingObserver.set_update_active(false);
+
+                       		# Do actual update
+                       		create_without_disable_update
+
+                       		# Reenable updates to perform a single update
+				GitHostingObserver.set_update_active(true);
+                       	end
+                        def update_with_disable_update
+                             	# Turn of updates during repository update
+                       		GitHostingObserver.set_update_active(false);
+
+                       		# Do actual update
+                       		update_without_disable_update
+
+                       		# Reenable updates to perform a single update
+				GitHostingObserver.set_update_active(true);
+                       	end
+                        def destroy_with_disable_update
+                             	# Turn of updates during repository update
+                       		GitHostingObserver.set_update_active(false);
+
+                       		# Do actual update
+                       		destroy_without_disable_update
+
+                       		# Reenable updates to perform a single update
+				GitHostingObserver.set_update_active(true);
+                       	end
+                        def edit_membership_with_disable_update
+                             	# Turn of updates during repository update
+                       		GitHostingObserver.set_update_active(false);
+
+                       		# Do actual update
+                       		edit_membership_without_disable_update
+
+                       		# Reenable updates to perform a single update
+				GitHostingObserver.set_update_active(true);
+                       	end
+
+			def self.included(base)
+				base.class_eval do
+					unloadable
+				end
+                        	begin
+                                	base.send(:alias_method_chain, :create, :disable_update)
+                                	base.send(:alias_method_chain, :update, :disable_update)
+                                	base.send(:alias_method_chain, :destroy, :disable_update)
+                                	base.send(:alias_method_chain, :edit_membershipt, :disable_update)
+                                rescue
+                                end
+			end
+		end
+	end
+end


### PR DESCRIPTION
_Note that the following patch is subsumed (included in) the resilience patch, issue #124_

This prevents a ridiculous number of calls to update_repositories caused by the fact that redmine saves to the repository model for every commit that it examines.  This patch also prevents multiple calls to update_repositories when adding groups to the membership of a project.

After applying the patches, you must migrate the plugins:

```
rake db:migrate_plugins
```

Restart afterwards.
