### PR TITLE
Custom temp folder

### DIFF
--- a/app/views/settings/_redmine_git_hosting.html.erb
+++ b/app/views/settings/_redmine_git_hosting.html.erb
@@ -47,6 +47,11 @@
 		<%= text_field_tag("settings[gitRepositoryBasePath]", @settings['gitRepositoryBasePath'], :size => 60) %>
 		<br />
 	</p>
+	<p>
+		<label><%= l(:label_git_repository_tmp_dir)%></label>
+		<%= text_field_tag("settings[gitTmpDir]", @settings['gitTmpDir'], :size => 60) %>
+		<br />
+	</p>
 
 
 	<h3><%= l(:label_git_cache_parameters)%></h3>

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -7,6 +7,7 @@
   label_gitolite_identity_public_key_file: Gitolite SSH Identity File (Public Key)
   label_gitolite_identity_file: Gitolite SSH Identity File (Private Key)
   label_git_repository_base_path: Git Repository Base Path (Relative to git user home)
+  label_git_repository_tmp_dir: Git temporary folder (leave empty to use the default one)
 
   field_git_daemon: Git Daemon
   field_git_http: Git Smart HTTP

--- a/config/locales/bs.yml
+++ b/config/locales/bs.yml
@@ -7,6 +7,7 @@
   label_gitolite_identity_public_key_file: Gitolite SSH Identity File (Public Key)
   label_gitolite_identity_file: Gitolite SSH Identity File (Private Key)
   label_git_repository_base_path: Git Repository Base Path (Relative to git user home)
+  label_git_repository_tmp_dir: Git temporary folder (leave empty to use the default one)
 
   field_git_daemon: Git Daemon
   field_git_http: Git Smart HTTP

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -7,6 +7,7 @@
   label_gitolite_identity_public_key_file: Gitolite SSH Identity File (Public Key)
   label_gitolite_identity_file: Gitolite SSH Identity File (Private Key)
   label_git_repository_base_path: Git Repository Base Path (Relative to git user home)
+  label_git_repository_tmp_dir: Git temporary folder (leave empty to use the default one)
 
   field_git_daemon: Git Daemon
   field_git_http: Git Smart HTTP

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -7,6 +7,7 @@
   label_gitolite_identity_public_key_file: Gitolite SSH Identity File (Public Key)
   label_gitolite_identity_file: Gitolite SSH Identity File (Private Key)
   label_git_repository_base_path: Git Repository Base Path (Relative to git user home)
+  label_git_repository_tmp_dir: Git temporary folder (leave empty to use the default one)
 
   field_git_daemon: Git Daemon
   field_git_http: Git Smart HTTP

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -7,6 +7,7 @@
   label_gitolite_identity_public_key_file: Gitolite SSH Identity File (Public Key)
   label_gitolite_identity_file: Gitolite SSH Identity File (Private Key)
   label_git_repository_base_path: Git Repository Base Path (Relative to git user home)
+  label_git_repository_tmp_dir: Git temporary folder (leave empty to use the default one)
 
   field_git_daemon: Git Daemon
   field_git_http: Git Smart HTTP

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -7,6 +7,7 @@
   label_gitolite_identity_public_key_file: Gitolite SSH Identity File (Public Key)
   label_gitolite_identity_file: Gitolite SSH Identity File (Private Key)
   label_git_repository_base_path: Git Repository Base Path (Relative to git user home)
+  label_git_repository_tmp_dir: Git temporary folder (leave empty to use the default one)
 
   field_git_daemon: Git Daemon
   field_git_http: Git Smart HTTP

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -7,6 +7,7 @@
   label_gitolite_identity_public_key_file: Gitolite SSH Identity File (Public Key)
   label_gitolite_identity_file: Gitolite SSH Identity File (Private Key)
   label_git_repository_base_path: Git Repository Base Path (Relative to git user home)
+  label_git_repository_tmp_dir: Git temporary folder (leave empty to use the default one)
 
   field_git_daemon: Git Daemon
   field_git_http: Git Smart HTTP

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,6 +7,7 @@
   label_gitolite_identity_public_key_file: Gitolite SSH Identity File (Public Key)
   label_gitolite_identity_file: Gitolite SSH Identity File (Private Key)
   label_git_repository_base_path: Git Repository Base Path (Relative to git user home)
+  label_git_repository_tmp_dir: Git temporary folder (leave empty to use the default one)
 
   field_git_daemon: Git Daemon
   field_git_http: Git Smart HTTP

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -7,6 +7,7 @@
   label_gitolite_identity_public_key_file: Gitolite SSH Identity File (Public Key)
   label_gitolite_identity_file: Gitolite SSH Identity File (Private Key)
   label_git_repository_base_path: Git Repository Base Path (Relative to git user home)
+  label_git_repository_tmp_dir: Git temporary folder (leave empty to use the default one)
 
   field_git_daemon: Git Daemon
   field_git_http: Git Smart HTTP

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -7,6 +7,7 @@
   label_gitolite_identity_public_key_file: Gitolite SSH Identity File (Public Key)
   label_gitolite_identity_file: Gitolite SSH Identity File (Private Key)
   label_git_repository_base_path: Git Repository Base Path (Relative to git user home)
+  label_git_repository_tmp_dir: Git temporary folder (leave empty to use the default one)
 
   field_git_daemon: Git Daemon
   field_git_http: Git Smart HTTP

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -7,6 +7,7 @@
   label_gitolite_identity_public_key_file: Gitolite SSH Identity File (Public Key)
   label_gitolite_identity_file: Gitolite SSH Identity File (Private Key)
   label_git_repository_base_path: Git Repository Base Path (Relative to git user home)
+  label_git_repository_tmp_dir: Git temporary folder (leave empty to use the default one)
 
   field_git_daemon: Git Daemon
   field_git_http: Git Smart HTTP

--- a/config/locales/gl.yml
+++ b/config/locales/gl.yml
@@ -7,6 +7,7 @@
   label_gitolite_identity_public_key_file: Gitolite SSH Identity File (Public Key)
   label_gitolite_identity_file: Gitolite SSH Identity File (Private Key)
   label_git_repository_base_path: Git Repository Base Path (Relative to git user home)
+  label_git_repository_tmp_dir: Git temporary folder (leave empty to use the default one)
 
   field_git_daemon: Git Daemon
   field_git_http: Git Smart HTTP

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -7,6 +7,7 @@
   label_gitolite_identity_public_key_file: Gitolite SSH Identity File (Public Key)
   label_gitolite_identity_file: Gitolite SSH Identity File (Private Key)
   label_git_repository_base_path: Git Repository Base Path (Relative to git user home)
+  label_git_repository_tmp_dir: Git temporary folder (leave empty to use the default one)
 
   field_git_daemon: Git Daemon
   field_git_http: Git Smart HTTP

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -7,6 +7,7 @@
   label_gitolite_identity_public_key_file: Gitolite SSH Identity File (Public Key)
   label_gitolite_identity_file: Gitolite SSH Identity File (Private Key)
   label_git_repository_base_path: Git Repository Base Path (Relative to git user home)
+  label_git_repository_tmp_dir: Git temporary folder (leave empty to use the default one)
 
   field_git_daemon: Git Daemon
   field_git_http: Git Smart HTTP

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -7,6 +7,7 @@
   label_gitolite_identity_public_key_file: Gitolite SSH Identity File (Public Key)
   label_gitolite_identity_file: Gitolite SSH Identity File (Private Key)
   label_git_repository_base_path: Git Repository Base Path (Relative to git user home)
+  label_git_repository_tmp_dir: Git temporary folder (leave empty to use the default one)
 
   field_git_daemon: Git Daemon
   field_git_http: Git Smart HTTP

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -7,6 +7,7 @@
   label_gitolite_identity_public_key_file: Gitolite SSH Identity File (Public Key)
   label_gitolite_identity_file: Gitolite SSH Identity File (Private Key)
   label_git_repository_base_path: Git Repository Base Path (Relative to git user home)
+  label_git_repository_tmp_dir: Git temporary folder (leave empty to use the default one)
 
   field_git_daemon: Git Daemon
   field_git_http: Git Smart HTTP

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -7,6 +7,7 @@
   label_gitolite_identity_public_key_file: Gitolite SSH Identity File (Public Key)
   label_gitolite_identity_file: Gitolite SSH Identity File (Private Key)
   label_git_repository_base_path: Git Repository Base Path (Relative to git user home)
+  label_git_repository_tmp_dir: Git temporary folder (leave empty to use the default one)
 
   field_git_daemon: Git Daemon
   field_git_http: Git Smart HTTP

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -7,6 +7,7 @@
   label_gitolite_identity_public_key_file: Gitolite SSH Identity File (Public Key)
   label_gitolite_identity_file: Gitolite SSH Identity File (Private Key)
   label_git_repository_base_path: Git Repository Base Path (Relative to git user home)
+  label_git_repository_tmp_dir: Git temporary folder (leave empty to use the default one)
 
   field_git_daemon: Git Daemon
   field_git_http: Git Smart HTTP

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -7,6 +7,7 @@
   label_gitolite_identity_public_key_file: Gitolite SSH Identity File (Public Key)
   label_gitolite_identity_file: Gitolite SSH Identity File (Private Key)
   label_git_repository_base_path: Git Repository Base Path (Relative to git user home)
+  label_git_repository_tmp_dir: Git temporary folder (leave empty to use the default one)
 
   field_git_daemon: Git Daemon
   field_git_http: Git Smart HTTP

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -7,6 +7,7 @@
   label_gitolite_identity_public_key_file: Gitolite SSH Identity File (Public Key)
   label_gitolite_identity_file: Gitolite SSH Identity File (Private Key)
   label_git_repository_base_path: Git Repository Base Path (Relative to git user home)
+  label_git_repository_tmp_dir: Git temporary folder (leave empty to use the default one)
 
   field_git_daemon: Git Daemon
   field_git_http: Git Smart HTTP

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -7,6 +7,7 @@
   label_gitolite_identity_public_key_file: Gitolite SSH Identity File (Public Key)
   label_gitolite_identity_file: Gitolite SSH Identity File (Private Key)
   label_git_repository_base_path: Git Repository Base Path (Relative to git user home)
+  label_git_repository_tmp_dir: Git temporary folder (leave empty to use the default one)
 
   field_git_daemon: Git Daemon
   field_git_http: Git Smart HTTP

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -7,6 +7,7 @@
   label_gitolite_identity_public_key_file: Gitolite SSH Identity File (Public Key)
   label_gitolite_identity_file: Gitolite SSH Identity File (Private Key)
   label_git_repository_base_path: Git Repository Base Path (Relative to git user home)
+  label_git_repository_tmp_dir: Git temporary folder (leave empty to use the default one)
 
   field_git_daemon: Git Daemon
   field_git_http: Git Smart HTTP

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -7,6 +7,7 @@ pt-BR:
   label_gitolite_identity_public_key_file: Gitolite SSH Identity File (Public Key)
   label_gitolite_identity_file: Ficheiro de identidade SSH Gitolite (Chave Privada)
   label_git_repository_base_path: 'Directório Git base (Relativo à "home" do utilizador git)'
+  label_git_repository_tmp_dir: Git temporary folder (leave empty to use the default one)
 
   field_git_daemon: Git Daemon
   field_git_http: Git Smart HTTP

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -7,6 +7,7 @@ pt:
   label_gitolite_identity_public_key_file: Gitolite SSH Identity File (Public Key)
   label_gitolite_identity_file: Ficheiro de identidade SSH Gitolite (Chave Privada)
   label_git_repository_base_path: 'Directório Git base (Relativo à "home" do utilizador git)'
+  label_git_repository_tmp_dir: Git temporary folder (leave empty to use the default one)
 
   field_git_daemon: Git Daemon
   field_git_http: Git Smart HTTP

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -7,6 +7,7 @@
   label_gitolite_identity_public_key_file: Gitolite SSH Identity File (Public Key)
   label_gitolite_identity_file: Gitolite SSH Identity File (Private Key)
   label_git_repository_base_path: Git Repository Base Path (Relative to git user home)
+  label_git_repository_tmp_dir: Git temporary folder (leave empty to use the default one)
 
   field_git_daemon: Git Daemon
   field_git_http: Git Smart HTTP

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -7,6 +7,7 @@
   label_gitolite_identity_public_key_file: Gitolite SSH Identity File (Public Key)
   label_gitolite_identity_file: Gitolite SSH Identity File (Private Key)
   label_git_repository_base_path: Git Repository Base Path (Relative to git user home)
+  label_git_repository_tmp_dir: Git temporary folder (leave empty to use the default one)
 
   field_git_daemon: Git Daemon
   field_git_http: Git Smart HTTP

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -7,6 +7,7 @@
   label_gitolite_identity_public_key_file: Gitolite SSH Identity File (Public Key)
   label_gitolite_identity_file: Gitolite SSH Identity File (Private Key)
   label_git_repository_base_path: Git Repository Base Path (Relative to git user home)
+  label_git_repository_tmp_dir: Git temporary folder (leave empty to use the default one)
 
   field_git_daemon: Git Daemon
   field_git_http: Git Smart HTTP

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -7,6 +7,7 @@
   label_gitolite_identity_public_key_file: Gitolite SSH Identity File (Public Key)
   label_gitolite_identity_file: Gitolite SSH Identity File (Private Key)
   label_git_repository_base_path: Git Repository Base Path (Relative to git user home)
+  label_git_repository_tmp_dir: Git temporary folder (leave empty to use the default one)
 
   field_git_daemon: Git Daemon
   field_git_http: Git Smart HTTP

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -7,6 +7,7 @@
   label_gitolite_identity_public_key_file: Gitolite SSH Identity File (Public Key)
   label_gitolite_identity_file: Gitolite SSH Identity File (Private Key)
   label_git_repository_base_path: Git Repository Base Path (Relative to git user home)
+  label_git_repository_tmp_dir: Git temporary folder (leave empty to use the default one)
 
   field_git_daemon: Git Daemon
   field_git_http: Git Smart HTTP

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -7,6 +7,7 @@
   label_gitolite_identity_public_key_file: Gitolite SSH Identity File (Public Key)
   label_gitolite_identity_file: Gitolite SSH Identity File (Private Key)
   label_git_repository_base_path: Git Repository Base Path (Relative to git user home)
+  label_git_repository_tmp_dir: Git temporary folder (leave empty to use the default one)
 
   field_git_daemon: Git Daemon
   field_git_http: Git Smart HTTP

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -7,6 +7,7 @@
   label_gitolite_identity_public_key_file: Gitolite SSH Identity File (Public Key)
   label_gitolite_identity_file: Gitolite SSH Identity File (Private Key)
   label_git_repository_base_path: Git Repository Base Path (Relative to git user home)
+  label_git_repository_tmp_dir: Git temporary folder (leave empty to use the default one)
 
   field_git_daemon: Git Daemon
   field_git_http: Git Smart HTTP

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -7,6 +7,7 @@
   label_gitolite_identity_public_key_file: Gitolite SSH Identity File (Public Key)
   label_gitolite_identity_file: Gitolite SSH Identity File (Private Key)
   label_git_repository_base_path: Git Repository Base Path (Relative to git user home)
+  label_git_repository_tmp_dir: Git temporary folder (leave empty to use the default one)
 
   field_git_daemon: Git Daemon
   field_git_http: Git Smart HTTP

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -7,6 +7,7 @@
   label_gitolite_identity_public_key_file: Gitolite SSH Identity File (Public Key)
   label_gitolite_identity_file: Gitolite SSH Identity File (Private Key)
   label_git_repository_base_path: Git Repository Base Path (Relative to git user home)
+  label_git_repository_tmp_dir: Git temporary folder (leave empty to use the default one)
 
   field_git_daemon: Git Daemon
   field_git_http: Git Smart HTTP

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -7,6 +7,7 @@
   label_gitolite_identity_public_key_file: Gitolite SSH Identity File (Public Key)
   label_gitolite_identity_file: Gitolite SSH Identity File (Private Key)
   label_git_repository_base_path: Git Repository Base Path (Relative to git user home)
+  label_git_repository_tmp_dir: Git temporary folder (leave empty to use the default one)
 
   field_git_daemon: Git Daemon
   field_git_http: Git Smart HTTP

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -7,6 +7,7 @@
   label_gitolite_identity_public_key_file: Gitolite SSH Identity File (Public Key)
   label_gitolite_identity_file: Gitolite SSH Identity File (Private Key)
   label_git_repository_base_path: Git Repository Base Path (Relative to git user home)
+  label_git_repository_tmp_dir: Git temporary folder (leave empty to use the default one)
 
   field_git_daemon: Git Daemon
   field_git_http: Git Smart HTTP

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -7,6 +7,7 @@
   label_gitolite_identity_public_key_file: Gitolite SSH Identity File (Public Key)
   label_gitolite_identity_file: Gitolite SSH Identity File (Private Key)
   label_git_repository_base_path: Git Repository Base Path (Relative to git user home)
+  label_git_repository_tmp_dir: Git temporary folder (leave empty to use the default one)
 
   field_git_daemon: Git Daemon
   field_git_http: Git Smart HTTP

--- a/init.rb
+++ b/init.rb
@@ -26,7 +26,8 @@ Redmine::Plugin.register :redmine_git_hosting do
 		'gitCacheMaxElements' => '100',
 		'gitCacheMaxSize' => '16',
 		'gitHooksDebug' => 'false',
-		'gitHooksAreAsynchronous' => 'true'
+		'gitHooksAreAsynchronous' => 'true',
+		'gitTmpDir' => '' # Leave empty to use Dir.tmpdir as usual
 		},
 		:partial => 'redmine_git_hosting'
 		project_module :repository do

--- a/lib/git_adapter_hooks.rb
+++ b/lib/git_adapter_hooks.rb
@@ -8,7 +8,7 @@ module GitHosting
 		@@check_hooks_installed_cached = nil
 
 		def self.check_hooks_installed
-			if not @@check_hooks_installed_cached.nil? and (Time.new - @@check_hooks_installed_stamp <= 0.5):
+			if not @@check_hooks_installed_cached.nil? and (Time.new - @@check_hooks_installed_stamp <= 0.5)
 				return @@check_hooks_installed_cached
 			end
 

--- a/lib/git_hosting.rb
+++ b/lib/git_hosting.rb
@@ -147,7 +147,7 @@ module GitHosting
 	end
 	def self.get_tmp_dir
 	  tmp_dir = Setting.plugin_redmine_git_hosting['gitTmpDir']
-	  @@git_hosting_tmp_dir = tmp_dir.empty? : nil ? tmp_dir
+	  @@git_hosting_tmp_dir = tmp_dir.empty? ? nil : tmp_dir
 		@@git_hosting_tmp_dir ||= File.join(Dir.tmpdir, "redmine_git_hosting")
 		if !File.directory?(@@git_hosting_tmp_dir)
 			%x[mkdir -p "#{@@git_hosting_tmp_dir}"]

--- a/lib/git_hosting.rb
+++ b/lib/git_hosting.rb
@@ -147,7 +147,7 @@ module GitHosting
 	end
 	def self.get_tmp_dir
 	  tmp_dir = Setting.plugin_redmine_git_hosting['gitTmpDir']
-	  @@git_hosting_tmp_dir = (tmp_dir.nil? || tmp_dir.empty?) ? nil : tmp_dir
+	  @@git_hosting_tmp_dir = (tmp_dir.nil? || tmp_dir.empty?) ? nil : File.join(tmp_dir, "redmine_git_hosting")
 		@@git_hosting_tmp_dir ||= File.join(Dir.tmpdir, "redmine_git_hosting")
 		if !File.directory?(@@git_hosting_tmp_dir)
 			%x[mkdir -p "#{@@git_hosting_tmp_dir}"]

--- a/lib/git_hosting.rb
+++ b/lib/git_hosting.rb
@@ -146,6 +146,8 @@ module GitHosting
 		end
 	end
 	def self.get_tmp_dir
+	  tmp_dir = Setting.plugin_redmine_git_hosting['gitTmpDir']
+	  @@git_hosting_tmp_dir = tmp_dir.empty? : nil ? tmp_dir
 		@@git_hosting_tmp_dir ||= File.join(Dir.tmpdir, "redmine_git_hosting")
 		if !File.directory?(@@git_hosting_tmp_dir)
 			%x[mkdir -p "#{@@git_hosting_tmp_dir}"]

--- a/lib/git_hosting.rb
+++ b/lib/git_hosting.rb
@@ -59,7 +59,7 @@ module GitHosting
 	@@sudo_git_to_web_user_stamp = nil
 	@@sudo_git_to_web_user_cached = nil
 	def self.sudo_git_to_web_user
-		if not @@sudo_git_to_web_user_cached.nil? and (Time.new - @@sudo_git_to_web_user_stamp <= 0.5):
+		if not @@sudo_git_to_web_user_cached.nil? and (Time.new - @@sudo_git_to_web_user_stamp <= 0.5)
 			return @@sudo_git_to_web_user_cached
 		end
 		logger.info "Testing if git user(\"#{git_user}\") can sudo to web user(\"#{web_user}\")"
@@ -83,7 +83,7 @@ module GitHosting
 	@@sudo_web_to_git_user_stamp = nil
 	@@sudo_web_to_git_user_cached = nil
 	def self.sudo_web_to_git_user
-		if not @@sudo_web_to_git_user_cached.nil? and (Time.new - @@sudo_web_to_git_user_stamp <= 0.5):
+		if not @@sudo_web_to_git_user_cached.nil? and (Time.new - @@sudo_web_to_git_user_stamp <= 0.5)
 			return @@sudo_web_to_git_user_cached
 		end
 		logger.info "Testing if web user(\"#{web_user}\") can sudo to git user(\"#{git_user}\")"

--- a/lib/git_hosting.rb
+++ b/lib/git_hosting.rb
@@ -147,7 +147,7 @@ module GitHosting
 	end
 	def self.get_tmp_dir
 	  tmp_dir = Setting.plugin_redmine_git_hosting['gitTmpDir']
-	  @@git_hosting_tmp_dir = (tmp_dir.nil? || tmp_dir.empty?) ? nil : File.join(tmp_dir, "redmine_git_hosting")
+	  @@git_hosting_tmp_dir = (tmp_dir.nil? || tmp_dir.strip.empty?) ? nil : File.join(tmp_dir, "redmine_git_hosting")
 		@@git_hosting_tmp_dir ||= File.join(Dir.tmpdir, "redmine_git_hosting")
 		if !File.directory?(@@git_hosting_tmp_dir)
 			%x[mkdir -p "#{@@git_hosting_tmp_dir}"]

--- a/lib/git_hosting.rb
+++ b/lib/git_hosting.rb
@@ -147,7 +147,7 @@ module GitHosting
 	end
 	def self.get_tmp_dir
 	  tmp_dir = Setting.plugin_redmine_git_hosting['gitTmpDir']
-	  @@git_hosting_tmp_dir = tmp_dir.empty? ? nil : tmp_dir
+	  @@git_hosting_tmp_dir = (tmp_dir.nil? || tmp_dir.empty?) ? nil : tmp_dir
 		@@git_hosting_tmp_dir ||= File.join(Dir.tmpdir, "redmine_git_hosting")
 		if !File.directory?(@@git_hosting_tmp_dir)
 			%x[mkdir -p "#{@@git_hosting_tmp_dir}"]


### PR DESCRIPTION
With these changes the user can select a different temp folder to manage the gitolite repository. If this custom option is ignored, the old behaviour still works and the plugin uses Dir.tmpdir.
In my case this patch is mandatory because the /tmp folder in my server is mounted with the noexec flag and the plugin doesn't work (it causes a 50x error).

Another little fix let this plugin work with ruby 1.9.3
